### PR TITLE
feat: add only one assert rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,20 +208,22 @@ by placing the following somewhere in the file (preferably at the top):
 | `PYNUDGER25` | Avoid restricted attribute manipulation: delattr, getattr, hasattr, setattr, globals, locals, vars, dir. |
 | `PYNUDGER26` | Avoid restricted explicit dunder access: attributes starting with `__`.                                  |
 | `PYNUDGER27` | Avoid returning empty strings. Return None to indicate lack of value.                                    |
+| `PYNUDGER28` | Avoid more than <N> assert statements in pytest tests. Keep each test focused.                           |
 
 with the following configurable options (in `pyproject.toml`
 or `.pynudger.toml`):
 
 <!-- pyml disable-num-lines 10 line-length-->
 
-| Option               | Description                                                           | Affected rules         | Default                                                    |
-| -------------------- | --------------------------------------------------------------------- | ---------------------- | ---------------------------------------------------------- |
-| `pascal_length`      | Maximum allowed length of PascalCase names                            | PYNUDGER15             | 3                                                          |
-| `snake_length`       | Maximum allowed length of snake_case names                            | PYNUDGER16, PYNUDGER17 | 3                                                          |
-| `pascal_excludes`    | List of words to exclude from PascalCase length check                 | PYNUDGER15             | []                                                         |
-| `snake_excludes`     | List of words to exclude from snake_case length check                 | PYNUDGER16, PYNUDGER17 | []                                                         |
-| `dir_ignores`        | List of (sub)directories to be excluded in case no files are provided | __ALL__                | ["\_\_pypackages\_\_", ".venv", ".git", "\_\_pycache\_\_"] |
-| `extend_dir_ignores` | Additional (sub)directories to ignore, extending the default ignores  | __ALL__                | []                                                         |
+| Option                 | Description                                                           | Affected rules         | Default                                                    |
+| ---------------------- | --------------------------------------------------------------------- | ---------------------- | ---------------------------------------------------------- |
+| `pascal_length`        | Maximum allowed length of PascalCase names                            | PYNUDGER15             | 3                                                          |
+| `snake_length`         | Maximum allowed length of snake_case names                            | PYNUDGER16, PYNUDGER17 | 3                                                          |
+| `pascal_excludes`      | List of words to exclude from PascalCase length check                 | PYNUDGER15             | []                                                         |
+| `snake_excludes`       | List of words to exclude from snake_case length check                 | PYNUDGER16, PYNUDGER17 | []                                                         |
+| `maximum_test_asserts` | Maximum number of `assert` statements in pytest tests                 | PYNUDGER28             | 1                                                          |
+| `dir_ignores`          | List of (sub)directories to be excluded in case no files are provided | __ALL__                | ["\_\_pypackages\_\_", ".venv", ".git", "\_\_pycache\_\_"] |
+| `extend_dir_ignores`   | Additional (sub)directories to ignore, extending the default ignores  | __ALL__                | []                                                         |
 
 ## Contribute
 

--- a/src/pynudger/rule/__init__.py
+++ b/src/pynudger/rule/__init__.py
@@ -22,6 +22,7 @@ from pynudger.rule import (
     length,
     setter,
     string,
+    testing,
     util,
 )
 
@@ -35,5 +36,6 @@ __all__ = [
     "length",
     "setter",
     "string",
+    "testing",
     "util",
 ]

--- a/src/pynudger/rule/length.py
+++ b/src/pynudger/rule/length.py
@@ -71,10 +71,7 @@ class _Length(lintkit.check.Check, abc.ABC):
             Length limit
 
         """
-        length = self.config.get(f"{self._variable()}_length")  # pyright: ignore[reportAttributeAccessIssue]
-        if length is None:
-            return 3
-        return length  # pragma: no cover
+        return self.config.get(f"{self._variable()}_length", 3)  # pyright: ignore[reportAttributeAccessIssue]
 
     def message(self, value: lintkit.Value[str]) -> str:
         """Display error message in case of rule violation.

--- a/src/pynudger/rule/testing.py
+++ b/src/pynudger/rule/testing.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: © 2025, 2026 open-nudge <https://github.com/open-nudge>
+# SPDX-FileContributor: szymonmaszke <github@maszke.co>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rules validating test structure."""
+
+from __future__ import annotations
+
+import ast
+import typing
+
+import lintkit
+
+if typing.TYPE_CHECKING:
+    import collections.abc
+
+
+class AssertCount(
+    lintkit.check.Check,
+    lintkit.loader.Python,
+    lintkit.rule.Node,
+    code=28,
+):
+    """Rule checking extra assert statements in pytest tests."""
+
+    def values(self) -> collections.abc.Iterable[lintkit.Value[ast.Assert]]:
+        """Yield assert statements from pytest-style functions.
+
+        Yields:
+            Assert statements inside matching test functions.
+
+        """
+        path = self.file.resolve()  # pyright: ignore[reportOptionalMemberAccess]
+        if not path.name.startswith("test") and not path.stem.endswith("test"):
+            return
+
+        data: list[ast.FunctionDef] = self.getitem("nodes_map")[ast.FunctionDef]
+        for function_def in data:
+            if function_def.name.startswith("test"):
+                self._count: int = 0
+                for statement in function_def.body:
+                    if isinstance(statement, ast.Assert):
+                        yield lintkit.Value.from_python(statement, statement)
+            else:  # pragma: no cover
+                pass
+
+    def check(self, _: lintkit.Value[ast.Assert]) -> bool:
+        """Report asserts only when a test contains too many of them.
+
+        Args:
+            _:
+                Loaded assert statement.
+
+        Returns:
+            True if the current test function has more than two asserts.
+
+        """
+        self._count += 1
+        return self._count > self._maximum_test_asserts()
+
+    def _maximum_test_asserts(self) -> int:
+        """Get maximum number of allowed asserts in test cases.
+
+        Returns:
+            Maximum number of allowed asserts in test cases.
+            Default: 1
+        """
+        return self.config.get("maximum_test_asserts", 1)  # pyright: ignore[reportAttributeAccessIssue]
+
+    def description(self) -> str:
+        """Return rule description.
+
+        Returns:
+            Description of the rule.
+
+        """
+        return (
+            f"Avoid more than {self._maximum_test_asserts()} assert "
+            "statements in pytest tests. Keep each test focused."
+        )
+
+    def message(self, _: lintkit.Value[ast.Assert]) -> str:
+        """Return a multiple-assert violation message.
+
+        Args:
+            _:
+                Extra assert statement.
+
+        Returns:
+            Message describing the rule violation.
+
+        """
+        return self.description()

--- a/tests/cases/clean/not_testing.py
+++ b/tests/cases/clean/not_testing.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: © 2025, 2026 open-nudge <https://github.com/open-nudge>
+# SPDX-FileContributor: szymonmaszke <github@maszke.co>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Module testing clean assert rule behavior."""
+
+from __future__ import annotations
+
+
+def testing() -> None:
+    """Use one assert statement."""
+    # nosemgrep
+    assert True

--- a/tests/cases/violations/testing.py
+++ b/tests/cases/violations/testing.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: © 2025, 2026 open-nudge <https://github.com/open-nudge>
+# SPDX-FileContributor: szymonmaszke <github@maszke.co>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Module testing multiple assert rule violations."""
+
+from __future__ import annotations
+
+
+def test_count() -> None:
+    """Use too many assert statements."""
+    # nosemgrep
+    assert True
+    # nosemgrep
+    assert True


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2025 open-nudge <https://github.com/open-nudge>
SPDX-FileContributor: szymonmaszke <github@maszke.co>

SPDX-License-Identifier: Apache-2.0
-->

<!--- pyml disable-next-line first-line-heading,first-line-h1-->

## Checklist

- [x] I agree to follow this project's [Code of Conduct](https://github.com/open-nudge/pynudger/blob/main/CODE_OF_CONDUCT.md)
- [x] I have read this project's [Contributing Guide](https://github.com/open-nudge/pynudger/blob/main/CONTRIBUTING.md)
- [x] I have created relevant issue(s) and linked them in the PR description

> Closes #24 